### PR TITLE
Added support for new regkey structure under v35

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.*~
 *.pyc
 .*.swp
+.vscode

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Tested and works on:
 - PSSE 32
 - PSSE 33
 - PSSE 34
+- PSSE 35
 
 Supports 32 and 64 bit windows (and provides warnings when using mismatched 64
 bit python when PSSE requires 32 bit python).

--- a/pssepath/__version__.py
+++ b/pssepath/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (0, 2, 1)
+VERSION = (0, 2, 2)
 
 __version__ = '.'.join(map(str, VERSION))

--- a/pssepath/core.py
+++ b/pssepath/core.py
@@ -133,6 +133,11 @@ def add_dir_to_path(psse_ver, psse_path):
         sys.path.insert(0, pssebin_dir)
         os.environ["PATH"] = pssebin_dir + ";" + os.environ["PATH"]
 
+    if int(psse_ver) == 35:
+        # PSSE 35 appears to require you to run the psse35 import, 
+        # otherwise psspy fails to initialise
+        import psse35
+
 
 def search_pssbin_reg_key(pti_key):
     pssbin_paths = {}


### PR DESCRIPTION
Updated to reflect the new registry key structure

Now keys are under:
> PTI\PSSE 35\5
for e.g. v35.5

It also appears that psspy will not initialise successfully unless you perform the magical invocation within import psse35. This means a static import -- not the greatest, but it works for now.